### PR TITLE
fix side scroll if you type many keys

### DIFF
--- a/lua/keycastr/init.lua
+++ b/lua/keycastr/init.lua
@@ -125,6 +125,7 @@ function M.show()
   local bufnr = state and state.bufnr or vim.api.nvim_create_buf(false, true)
   local winid = vim.api.nvim_open_win(bufnr, false, config_to_open_win(config))
   vim.api.nvim_set_option_value("cursorline", false, { win = winid })
+  vim.api.nvim_set_option_value("wrap", false, { win = winid })
   if state then
     state.winid = winid
   else


### PR DESCRIPTION
Close #1 

`leftcol` key in `winsaveview()` is enable if and only if `wrap` is false.
And `wrap` is `true` on default.

so I set `wrap` to false.